### PR TITLE
remove tilde from less imports

### DIFF
--- a/packages/nav-frontend-alertstriper-style/src/index.less
+++ b/packages/nav-frontend-alertstriper-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_mixins";
-@import (reference) "~nav-frontend-paneler-style/src/mixins";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_mixins";
+@import (reference) "nav-frontend-paneler-style/src/mixins";
 
 .alertstripe {
   .panel-mixin();

--- a/packages/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -1,7 +1,7 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-chevron-style/src/mixins";
-@import (reference) "~nav-frontend-paneler-style/src/mixins";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-chevron-style/src/mixins";
+@import (reference) "nav-frontend-paneler-style/src/mixins";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .ReactCollapse--collapse {
   transition: height 250ms cubic-bezier(0.4, 0, 0.2, 1);

--- a/packages/nav-frontend-etiketter-style/src/index.less
+++ b/packages/nav-frontend-etiketter-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_variabler";
 @import "./_mixins";
 
 .etikett {

--- a/packages/nav-frontend-grid-style/src/index.less
+++ b/packages/nav-frontend-grid-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_mixins";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_mixins";
 @import "./mixins";
 
 //

--- a/packages/nav-frontend-hjelpetekst-style/src/hjelpetekst-style.less
+++ b/packages/nav-frontend-hjelpetekst-style/src/hjelpetekst-style.less
@@ -1,7 +1,7 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_mixins";
-@import (reference) "~nav-frontend-typografi-style/src/fontimports";
-@import (reference) "~nav-frontend-typografi-style/src/mixins";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_mixins";
+@import (reference) "nav-frontend-typografi-style/src/fontimports";
+@import (reference) "nav-frontend-typografi-style/src/mixins";
 
 .hjelpetekst {
   position: relative;

--- a/packages/nav-frontend-knapper-style/src/index.less
+++ b/packages/nav-frontend-knapper-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_mixins";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_mixins";
+@import (reference) "nav-frontend-typografi-style/src/index";
 @import "./mixins";
 
 .knapp {

--- a/packages/nav-frontend-lenkepanel-style/src/index.less
+++ b/packages/nav-frontend-lenkepanel-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-chevron-style/src/mixins";
-@import (reference) "~nav-frontend-paneler-style/src/mixins";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-chevron-style/src/mixins";
+@import (reference) "nav-frontend-paneler-style/src/mixins";
 
 .lenkepanel {
   .panel-mixin();

--- a/packages/nav-frontend-lenker-style/src/lenker-mixins.less
+++ b/packages/nav-frontend-lenker-style/src/lenker-mixins.less
@@ -1,4 +1,4 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_variabler";
 
 .lenke-mixin() {
   color: @navBla;

--- a/packages/nav-frontend-lesmerpanel-style/src/lesmerpanel-style.less
+++ b/packages/nav-frontend-lesmerpanel-style/src/lesmerpanel-style.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-paneler-style/src/mixins";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-paneler-style/src/mixins";
 
 .lesMerPanel {
   .panel-mixin();

--- a/packages/nav-frontend-lukknapp-style/src/lukknapp-style.less
+++ b/packages/nav-frontend-lukknapp-style/src/lukknapp-style.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/hide-text";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/hide-text";
 
 .lukknapp {
   .hide-text();

--- a/packages/nav-frontend-modal-style/src/index.less
+++ b/packages/nav-frontend-modal-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) "~nav-frontend-core/less/hide-text";
-@import (reference) "~nav-frontend-paneler-style/src/mixins";
-@import (reference) "~nav-frontend-lukknapp-style/src/lukknapp-style";
+@import (reference) "nav-frontend-core/less/hide-text";
+@import (reference) "nav-frontend-paneler-style/src/mixins";
+@import (reference) "nav-frontend-lukknapp-style/src/lukknapp-style";
 
 .ReactModal__Body--open {
   overflow: hidden;

--- a/packages/nav-frontend-paneler-style/src/mixins.less
+++ b/packages/nav-frontend-paneler-style/src/mixins.less
@@ -1,4 +1,4 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_variabler";
 
 .panel-mixin() {
   background-color: @white;

--- a/packages/nav-frontend-popover-style/src/popover-style.less
+++ b/packages/nav-frontend-popover-style/src/popover-style.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_elevasjon";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_elevasjon";
 
 .popover {
   position: relative;

--- a/packages/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
+++ b/packages/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-paneler-style";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-paneler-style";
+@import (reference) "nav-frontend-typografi-style/src/index";
 @import "./assets/symbols";
 
 .bekreftCheckboksPanel {

--- a/packages/nav-frontend-skjema-style/src/checkbox.less
+++ b/packages/nav-frontend-skjema-style/src/checkbox.less
@@ -1,5 +1,5 @@
 @import "assets/symbols";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .mixin-transition(@varighet: 150ms, @type: all) {
   transition: @type @varighet cubic-bezier(0.465, 0.183, 0.153, 0.946);

--- a/packages/nav-frontend-skjema-style/src/feiloppsummering.less
+++ b/packages/nav-frontend-skjema-style/src/feiloppsummering.less
@@ -1,6 +1,6 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-paneler-style";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-paneler-style";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .feiloppsummering {
   .panel-mixin();

--- a/packages/nav-frontend-skjema-style/src/index.less
+++ b/packages/nav-frontend-skjema-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-typografi-style/src/index";
 @import "checkbox";
 @import "radioknapp";
 @import "textarea";

--- a/packages/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/nav-frontend-skjema-style/src/input-panel.less
@@ -1,5 +1,5 @@
 @import "./assets/symbols";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .inputPanelGruppe {
   &__inner + div > .skjemaelement__feilmelding {

--- a/packages/nav-frontend-skjema-style/src/input.less
+++ b/packages/nav-frontend-skjema-style/src/input.less
@@ -1,5 +1,5 @@
 // lesshint qualifyingElement: false
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .input--xxs {
   width: 35px;

--- a/packages/nav-frontend-skjema-style/src/radioknapp.less
+++ b/packages/nav-frontend-skjema-style/src/radioknapp.less
@@ -1,4 +1,4 @@
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .radioknapp {
   .typo-normal-mixin();

--- a/packages/nav-frontend-skjema-style/src/skjema-gruppe.less
+++ b/packages/nav-frontend-skjema-style/src/skjema-gruppe.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .skjemagruppe,
 .skjemagruppe fieldset,

--- a/packages/nav-frontend-skjema-style/src/textarea.less
+++ b/packages/nav-frontend-skjema-style/src/textarea.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .textarea--medMeta {
   resize: none;

--- a/packages/nav-frontend-skjema-style/src/toggle.less
+++ b/packages/nav-frontend-skjema-style/src/toggle.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/core";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/core";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .toggle {
   display: flex;

--- a/packages/nav-frontend-snakkeboble-style/src/snakkeboble-style.less
+++ b/packages/nav-frontend-snakkeboble-style/src/snakkeboble-style.less
@@ -1,8 +1,8 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_mixins";
-@import (reference) "~nav-frontend-core/less/utilities";
-@import (reference) "~nav-frontend-core/less/hide-text";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_mixins";
+@import (reference) "nav-frontend-core/less/utilities";
+@import (reference) "nav-frontend-core/less/hide-text";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .snakkeboble {
   display: flex;

--- a/packages/nav-frontend-stegindikator-style/src/index.less
+++ b/packages/nav-frontend-stegindikator-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 @hvit: @white; //deprecated in core
 @aktivBlaa: @navDypBla;

--- a/packages/nav-frontend-tabell-style/src/index.less
+++ b/packages/nav-frontend-tabell-style/src/index.less
@@ -1,7 +1,7 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-core/less/_mixins";
-@import (reference) "~nav-frontend-typografi-style/src/index";
-@import (reference) "~nav-frontend-knapper-style";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_mixins";
+@import (reference) "nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-knapper-style";
 
 .tabell {
   border-collapse: collapse;

--- a/packages/nav-frontend-tabs-style/src/tabs-style.less
+++ b/packages/nav-frontend-tabs-style/src/tabs-style.less
@@ -1,5 +1,5 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-typografi-style/src/index";
 
 .nav-frontend-tabs {
   border-bottom: 1px solid @navGra20;

--- a/packages/nav-frontend-toggle-style/src/toggle-style.less
+++ b/packages/nav-frontend-toggle-style/src/toggle-style.less
@@ -1,7 +1,7 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-typografi-style/src/index";
-@import (reference) "~nav-frontend-knapper-style/src/index";
-@import (reference) "~nav-frontend-knapper-style/src/mixins";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-typografi-style/src/index";
+@import (reference) "nav-frontend-knapper-style/src/index";
+@import (reference) "nav-frontend-knapper-style/src/mixins";
 
 .toggleKnapp {
   .knappbase-mixin(@font-family);

--- a/packages/nav-frontend-typografi-style/src/index.less
+++ b/packages/nav-frontend-typografi-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_variabler";
 @import "fontimports";
 @import "mixins";
 

--- a/packages/nav-frontend-typografi/md/Typografi.overview.mdx
+++ b/packages/nav-frontend-typografi/md/Typografi.overview.mdx
@@ -49,7 +49,7 @@ kan det være greit å legge til manuelt da man sikrer at hele prosjektet får r
 Dette kan gjøres ved å legge til
 
 ```less
-@import (reference) "~nav-frontend-typografi-style/src/index.less";
+@import (reference) "nav-frontend-typografi-style/src/index.less";
 ```
 
 i ønsket less fil og da legge til klassen `app` på elementet som pakker in prosjektet ditt.

--- a/packages/nav-frontend-veileder-style/src/index.less
+++ b/packages/nav-frontend-veileder-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-core/less/_variabler";
 
 .nav-veileder {
   align-items: center;

--- a/packages/nav-frontend-veilederpanel-style/src/index.less
+++ b/packages/nav-frontend-veilederpanel-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) "~nav-frontend-core/less/_variabler";
-@import (reference) "~nav-frontend-paneler-style/src/mixins";
-@import (reference) "~nav-frontend-typografi-style";
+@import (reference) "nav-frontend-core/less/_variabler";
+@import (reference) "nav-frontend-paneler-style/src/mixins";
+@import (reference) "nav-frontend-typografi-style";
 
 .nav-veilederpanel {
   .panel-mixin();


### PR DESCRIPTION
Tilde er deprecated (det funker faktisk ikke med lessc): https://webpack.js.org/loaders/less-loader/#webpack-resolver